### PR TITLE
[ci] add GHA to release ztm-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,291 @@
+name: Release ZTM Cli
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+      - '*.*.*'
+      - '*.*.*-*'
+env:
+  PACKAGE_OUTPUT: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  set-release-version:
+    name: set-release-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set RELEASE_VERSION
+        id: version
+        run: |
+          pwd
+          ls -l
+          CI_COMMIT_DATE=$(git log -1 --format="%ad" --date=format:"%Y%m%d%H%M")
+          echo "CI_COMMIT_DATE=${CI_COMMIT_DATE}" >> $GITHUB_ENV
+          git fetch --tags
+          RELEASE_VERSION=`git name-rev --tags --name-only $(git rev-parse HEAD)`
+          if [ $RELEASE_VERSION = 'undefined' ]
+          then
+              echo "release_version=nightly-${CI_COMMIT_DATE}" >> $GITHUB_OUTPUT
+              echo "version=nightly" >> $GITHUB_OUTPUT
+              echo "commit_date=${CI_COMMIT_DATE}" >> $GITHUB_OUTPUT
+          else
+              echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+              echo "commit_date=${CI_COMMIT_DATE}" >> $GITHUB_OUTPUT
+          fi
+
+          CI_COMMIT_SHA=$(git log -1 --format=%H)
+          echo "commit_sha=$CI_COMMIT_SHA"  >> $GITHUB_OUTPUT
+
+      - name: Show envs
+        run: export
+    outputs:
+      release_version: ${{steps.version.outputs.release_version}}
+      commit_date: ${{steps.version.outputs.commit_date}}
+      commit_sha: ${{steps.version.outputs.commit_sha}}
+
+  build-ztm-cli-linux-x86_64:
+    needs: set-release-version
+    name: build-ztm-cli-linux-x86_64
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build
+        id: build
+        env:
+          RELEASE_VERSION: ${{ needs.set-release-version.outputs.release_version }}
+          ZTM_VERSION: ${{needs.set-release-version.outputs.release_version}}
+          ZTM_COMMIT_SHA: ${{needs.set-release-version.outputs.commit_sha}}
+          ZTM_COMMIT_DATE: ${{needs.set-release-version.outputs.commit_date}}
+        run: |
+          set -x
+          ./build.sh
+          ls -al
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ztm-cli-${{needs.set-release-version.outputs.release_version}}-generic_linux-x86_64.tar.gz
+          path: ztm-cli-${{needs.set-release-version.outputs.release_version}}-generic_linux-x86_64.tar.gz
+
+  build-ztm-cli-linux-arm64:
+    needs: set-release-version
+    name: build-ztm-cli-linux-arm64
+    runs-on: [self-hosted, linux, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build
+        id: build
+        env:
+          RELEASE_VERSION: ${{ needs.set-release-version.outputs.release_version }}
+          ZTM_VERSION: ${{needs.set-release-version.outputs.release_version}}
+          ZTM_COMMIT_SHA: ${{needs.set-release-version.outputs.commit_sha}}
+          ZTM_COMMIT_DATE: ${{needs.set-release-version.outputs.commit_date}}
+        run: |
+          set -x
+          ./build.sh
+          ls -al
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ztm-cli-${{needs.set-release-version.outputs.release_version}}-generic_linux-arm64.tar.gz
+          path: ztm-cli-${{needs.set-release-version.outputs.release_version}}-generic_linux-arm64.tar.gz
+
+  build-ztm-cli-macos-x64:
+    needs: set-release-version
+    name: build-ztm-cli-macos-x64
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build
+        id: build
+        env:
+          RELEASE_VERSION: ${{ needs.set-release-version.outputs.release_version }}
+          ZTM_VERSION: ${{needs.set-release-version.outputs.release_version}}
+          ZTM_COMMIT_SHA: ${{needs.set-release-version.outputs.commit_sha}}
+          ZTM_COMMIT_DATE: ${{needs.set-release-version.outputs.commit_date}}
+        run: |
+          set -x
+          ./build.sh
+          ls -al
+          uname -m
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ztm-cli-${{needs.set-release-version.outputs.release_version}}-macos-x86_64.tar.gz
+          path: ztm-cli-${{needs.set-release-version.outputs.release_version}}-macos-x86_64.tar.gz
+
+  build-ztm-cli-macos-arm64:
+    needs: set-release-version
+    name: build-ztm-cli-macos-arm64
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build
+        id: build
+        env:
+          RELEASE_VERSION: ${{ needs.set-release-version.outputs.release_version }}
+          ZTM_VERSION: ${{needs.set-release-version.outputs.release_version}}
+          ZTM_COMMIT_SHA: ${{needs.set-release-version.outputs.commit_sha}}
+          ZTM_COMMIT_DATE: ${{needs.set-release-version.outputs.commit_date}}
+        run: |
+          set -x
+          ./build.sh
+          ls -al
+          uname -m
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ztm-cli-${{needs.set-release-version.outputs.release_version}}-macos-arm64.tar.gz
+          path: ztm-cli-${{needs.set-release-version.outputs.release_version}}-macos-arm64.tar.gz
+
+  build-ztm-cli-win-x64:
+    needs: set-release-version
+    name: build-ztm-cli-win-x64
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: cmd
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.25.0"
+          ninjaVersion: "^1.11.1"
+
+      - name: Install NASM
+        uses: ilammy/setup-nasm@v1
+
+      - name: Build
+        id: build
+        env:
+          RELEASE_VERSION: ${{ needs.set-release-version.outputs.release_version }}
+          ZTM_VERSION: ${{needs.set-release-version.outputs.release_version}}
+          ZTM_COMMIT_SHA: ${{needs.set-release-version.outputs.commit_sha}}
+          ZTM_COMMIT_DATE: ${{needs.set-release-version.outputs.commit_date}}
+        run: |
+          .\build.cmd
+          dir
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ztm-cli-${{needs.set-release-version.outputs.release_version}}-win-x86_64.zip
+          path: ztm-cli-${{needs.set-release-version.outputs.release_version}}-win-x86_64.zip
+
+  build-libztm-android:
+    needs: set-release-version
+    name: build-libztm-android
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r26c
+
+      - uses: seanmiddleditch/gha-setup-ninja@v4
+        id: setup-ninja
+        with:
+          version: 1.11.1
+
+      - name: Build
+        id: build
+        env:
+          RELEASE_VERSION: ${{ needs.set-release-version.outputs.release_version }}
+          ZTM_VERSION: ${{needs.set-release-version.outputs.release_version}}
+          ZTM_COMMIT_SHA: ${{needs.set-release-version.outputs.commit_sha}}
+          ZTM_COMMIT_DATE: ${{needs.set-release-version.outputs.commit_date}}
+          BUILD_ZTM_SHARED: true
+          NDK: "${{ steps.setup-ndk.outputs.ndk-path }}"
+        run: |
+          set -x
+          ./build.sh
+          ls -al
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: libztm-${{needs.set-release-version.outputs.release_version}}-android.tar.gz
+          path: libztm-${{needs.set-release-version.outputs.release_version}}-android.tar.gz
+
+  create-release:
+    name: create release
+    runs-on: ubuntu-20.04
+    needs:
+      - set-release-version
+      - build-ztm-cli-linux-x86_64
+      - build-ztm-cli-linux-arm64
+      - build-ztm-cli-macos-x64
+      - build-ztm-cli-macos-arm64
+      - build-ztm-cli-win-x64
+      - build-libztm-android
+    env:
+      ZTM_VERSION: ${{needs.set-release-version.outputs.release_version}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Check downloads
+        run: |
+          ls -alR
+
+      - name: Create draft release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          tag_name: ${{needs.set-release-version.outputs.release_version}}
+          files: |
+            ztm-cli-${{env.ZTM_VERSION}}-generic_linux-x86_64.tar.gz/ztm-cli-${{env.ZTM_VERSION}}-generic_linux-x86_64.tar.gz
+            ztm-cli-${{env.ZTM_VERSION}}-generic_linux-arm64.tar.gz/ztm-cli-${{env.ZTM_VERSION}}-generic_linux-arm64.tar.gz
+            ztm-cli-${{env.ZTM_VERSION}}-macos-x86_64.tar.gz/ztm-cli-${{env.ZTM_VERSION}}-macos-x86_64.tar.gz
+            ztm-cli-${{env.ZTM_VERSION}}-macos-arm64.tar.gz/ztm-cli-${{env.ZTM_VERSION}}-macos-arm64.tar.gz
+            ztm-cli-${{env.ZTM_VERSION}}-win-x64.zip/ztm-cli-${{env.ZTM_VERSION}}-win-x64.zip
+            lib-ztm-${{env.ZTM_VERSION}}-android.tar.gz/libztm-${{env.ZTM_VERSION}}-android.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/
 cli/version.json
 agent/version.json
 agent/gui
+version.env
+usr/

--- a/build.cmd
+++ b/build.cmd
@@ -9,3 +9,7 @@ IF NOT EXIST bin (MD bin)
 COPY pipy\bin\Release\pipy.exe bin\ztm.exe
 
 ECHO The final product is ready at bin\ztm.exe
+
+if defined PACKAGE_OUTPUT (
+tar.exe -cf ztm-cli-%ZTM_VERSION%-win-x86_64.zip bin\ztm.exe
+)

--- a/build.sh
+++ b/build.sh
@@ -1,38 +1,27 @@
-#!/bin/sh
-
-check_version() {
-  if [ `printf '%s\n%s' $1 $2 | sort -V | head -n1` = $1 ]; then
-    echo $3
-    exit 1
-  fi
-}
-
-check_version `node -v` 'v16' 'Require Node.js version 16 or above'
+#!/bin/bash
 
 ZTM_DIR=$(cd "$(dirname "$0")" && pwd)
-ZTM_BIN="$ZTM_DIR/bin/ztm"
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  export OS_NAME=generic_linux
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  export OS_NAME=macos
+fi
+
+export OS_ARCH=$(uname -m)
+if [[ $OS_ARCH == "aarch64" ]]
+then
+  export OS_ARCH=arm64
+fi
 
 cd "$ZTM_DIR"
 build/deps.sh
 
 if [ $? -ne 0 ]; then
+  echo "Prepare deps failed, exit..."
   exit 1
 fi
 
 cd "$ZTM_DIR"
 build/gui.sh
 build/pipy.sh
-
-git submodule update --init
-
-cd "$ZTM_DIR/pipy"
-npm install --no-audit
-
-cd "$ZTM_DIR/gui"
-npm install --no-audit
-
-mkdir -p "$ZTM_DIR/bin"
-rm -f "$ZTM_BIN"
-cp -f "$ZTM_DIR/pipy/bin/pipy" "$ZTM_BIN"
-
-echo "The final product is ready at $ZTM_BIN"

--- a/build/deps.cmd
+++ b/build/deps.cmd
@@ -17,7 +17,12 @@ CMD /c "npm install --no-audit"
 
 CD "%cur_dir%"
 
+if defined ZTM_VERSION (
+set VERSION=%ZTM_VERSION%
+) else (
 FOR /f %%i IN ('git describe --abbrev^=0 --tags') DO SET VERSION=%%i
+)
+
 FOR /f %%i IN ('git log -1 --format^=%%H') DO SET COMMIT=%%i
 FOR /f "eol= tokens=* delims=" %%i IN ('"git log -1 --format=%%cD"') DO SET COMMIT_DATE=%%i
 

--- a/build/gui.sh
+++ b/build/gui.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ZTM_DIR=$(cd "$(dirname "$0")" && cd .. && pwd)
 

--- a/build/pipy.sh
+++ b/build/pipy.sh
@@ -1,17 +1,114 @@
-#!/bin/sh
+#!/bin/bash
 
 ZTM_DIR=$(cd "$(dirname "$0")" && cd .. && pwd)
+ZTM_BIN="$ZTM_DIR/bin/ztm"
+
+rm -rf $ZTM_DIR/pipy/build
 
 mkdir -p "$ZTM_DIR/pipy/build"
 cd "$ZTM_DIR/pipy/build"
 
-cmake .. \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_C_COMPILER=clang \
-  -DCMAKE_CXX_COMPILER=clang++ \
-  -DPIPY_GUI=OFF \
-  -DPIPY_CODEBASES=ON \
-  -DPIPY_CUSTOM_CODEBASES=ztm/ca:../ca,ztm/hub:../hub,ztm/agent:../agent,ztm/cli:../cli \
-  -DPIPY_DEFAULT_OPTIONS="repo://ztm/cli --args"
+if [ -z "$BUILD_ZTM_SHARED" ]
+then
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DPIPY_GUI=OFF \
+    -DPIPY_CODEBASES=ON \
+    -DPIPY_CUSTOM_CODEBASES=ztm/ca:../ca,ztm/hub:../hub,ztm/agent:../agent,ztm/cli:../cli \
+    -DPIPY_DEFAULT_OPTIONS="repo://ztm/cli --args"
 
-make -j2
+  make -j2
+
+  mkdir -p "$ZTM_DIR/bin"
+  rm -f "$ZTM_BIN"
+  cp -f "$ZTM_DIR/pipy/bin/pipy" "$ZTM_BIN"
+
+  echo "The final product is ready at $ZTM_BIN"
+else
+  export PIPY_DIR=${ZTM_DIR}/pipy
+  if [ -z "$NDK"  ] || [ ! -f "$NDK/build/cmake/android.toolchain.cmake" ]
+  then
+    echo "Can't find NDK, exists..."
+    exit 1
+  fi
+
+  export ANDROID_NDK_ROOT=$NDK
+
+#### Build OpenSSL
+  cd $PIPY_DIR/deps/openssl-3.2.0
+
+  mkdir -p android && cd android
+
+  ANDROID_TARGET_API=34
+  ANDROID_TARGET_ABI=arm64-v8a
+
+  OUTPUT=${PWD}/${ANDROID_TARGET_ABI}
+
+  PATH=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
+  ../config android-arm64 -D__ANDROID_API__=${ANDROID_TARGET_API} -fPIC -static no-asm no-shared no-tests --prefix=${OUTPUT}
+
+  make
+  make install_sw
+
+#### Build libztm.so
+  cd $PIPY_DIR/build
+
+  cmake .. \
+    -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake \
+    -DANDROID_ABI=arm64-v8a \
+    -DANDROID_PLATFORM=android-34 \
+    -DCMAKE_ANDROID_STL_TYPE=c++_static \
+    -DCMAKE_MAKE_PROGRAM=ninja \
+    -DANDROID_ALLOW_UNDEFINED_SYMBOLS=TRUE \
+    -DPIPY_OPENSSL=${ZTM_DIR}/pipy/deps/openssl-3.2.0/android/arm64-v8a \
+    -DPIPY_USE_SYSTEM_ZLIB=ON \
+    -DZLIB_LIBRARY=/usr/lib/x86_64-linux-gnu/libz.a -DZLIB_INCLUDE_DIR=/usr/lib/x86_64-linux-gnu \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DPIPY_SHARED=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPIPY_GUI=OFF \
+    -DPIPY_CODEBASES=ON \
+    -DPIPY_CUSTOM_CODEBASES=ztm/ca:../ca,ztm/hub:../hub,ztm/agent:../agent,ztm/cli:../cli \
+    -DPIPY_DEFAULT_OPTIONS="repo://ztm/cli --args" \
+    -GNinja 
+
+  ninja
+
+  if [ $? -ne 0 ]
+  then
+    echo "libztm.so build failed, exit..."
+    exit 1
+  fi
+
+  cd $ZTM_DIR
+
+  mkdir -p usr/local/lib
+  cp $ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so $ZTM_DIR/usr/local/lib
+  cp $PIPY_DIR/build/libpipy.so $ZTM_DIR/usr/local/lib/libztm.so
+
+  echo "The libztm.so is ready at $ZTM_DIR/usr/local/lib/libztm.so"
+fi
+
+if [ -n "$PACKAGE_OUTPUT" ]
+then
+  cd $ZTM_DIR
+
+  if [ ! -f version.env ]
+  then
+    echo "Missing version info, skip package..."
+    exit 0
+  fi
+
+  bin/ztm version
+
+  source version.env
+
+  if [ -z "$BUILD_ZTM_SHARED" ]
+  then
+    tar zcvf ztm-cli-${VERSION}-${OS_NAME}-${OS_ARCH}.tar.gz bin/ztm
+  else
+    tar zcvf libztm-${VERSION}-android.tar.gz usr/local/lib/*.so
+  fi
+fi


### PR DESCRIPTION
When push tag in format like:
- 0.0.1
- v0.0.1
- 0.0.1-rc.1
- v0.0.1-rc.2

will compile ztm-cli for:

- linux x86_64 and arm64
- macos x86_64 and arm64
- win x86_64
- libztm.so (for android)

and push the packages to draft release. 