### PR TITLE
Hole punch support for tunnel app

### DIFF
--- a/agent/apps/ztm/tunnel/api.js
+++ b/agent/apps/ztm/tunnel/api.js
@@ -247,7 +247,7 @@ export default function ({ app, mesh, punch }) {
           punch.createInboundHole($selectedEP)
           var hole = punch.findHole($selectedEP)
           if(hole && hole.ready()) {
-            console.info("Using direct session: ", hole)
+            console.info("Using direct session")
             return hole.directSession()
           }
           console.info("Using hub forwarded session")
@@ -396,25 +396,21 @@ export default function ({ app, mesh, punch }) {
     )
   )
 
-  var $hole = null
+  var tunnelHole = null
   var makeRespTunnel = pipeline($=>$
     .onStart(ctx => {
       console.info("Making resp tunnel: ", ctx)
       var ep = ctx.peer.id
-      $hole = punch.findHole(ep)
-      if(!$hole) throw `Invalid Hole State for ${ep}`
+      tunnelHole = punch.findHole(ep)
+      if(!tunnelHole) throw `Invalid Hole State for ${ep}`
       return new Data
     })
     .pipe(() => {
-      var p = $hole.makeRespTunnel()
-      $hole = null
+      var p = tunnelHole.makeRespTunnel()
+      tunnelHole = null
       return p
-    })
+    }, () => tunnelHole)
   )
-
-  // var makeRespTunnel = pipeline($=>$
-  //   .pipe(punch.makeRespTunnel())
-  // )
 
   getLocalConfig().then(applyLocalConfig)
 

--- a/agent/apps/ztm/tunnel/api.js
+++ b/agent/apps/ztm/tunnel/api.js
@@ -40,10 +40,9 @@ export default function ({ app, mesh, punch }) {
     if (ep === app.endpoint.id) {
       return getLocalConfig().then(
         config => {
-          var inbound = config.inbound.find(
+          config.inbound.find(
             i => i.protocol === protocol && i.name === name
           ) || null
-          var hole = punch.findHole(ep)
         }
       )
     } else {
@@ -227,8 +226,6 @@ export default function ({ app, mesh, punch }) {
     currentListens = []
     currentTargets = {}
 
-    console.info(`Applying config: ${JSON.encode(config)}`)
-
     config.inbound.forEach(i => {
       var protocol = i.protocol
       var name = i.name
@@ -245,10 +242,10 @@ export default function ({ app, mesh, punch }) {
           punch.createInboundHole($selectedEP)
           var hole = punch.findHole($selectedEP)
           if(hole && hole.ready()) {
-            console.info("Using direct session")
+            app.log("Using direct session")
             return hole.directSession()
           }
-          console.info("Using hub forwarded session")
+          app.log("Using hub forwarded session")
           return pipeline($=>$
             .muxHTTP().to($=>$
               .pipe(mesh.connect($selectedEP))
@@ -341,7 +338,6 @@ export default function ({ app, mesh, punch }) {
         return new StreamEnd
       })
       .onEnd(() => {
-        console.info('Answers in api: ', $response)
         return $response
       })
     ).spawn()
@@ -397,7 +393,6 @@ export default function ({ app, mesh, punch }) {
   var tunnelHole = null
   var makeRespTunnel = pipeline($=>$
     .onStart(ctx => {
-      console.info("Making resp tunnel: ", ctx)
       var ep = ctx.peer.id
       tunnelHole = punch.findHole(ep)
       if(!tunnelHole) throw `Invalid Hole State for ${ep}`

--- a/agent/apps/ztm/tunnel/api.js
+++ b/agent/apps/ztm/tunnel/api.js
@@ -173,23 +173,21 @@ export default function ({ app, mesh, punch }) {
     }
   }
 
-  function createHole(ep, ip, port, role) {
+  function createHole(ep, role) {
     var h = punch.findHole(ep)
     if(h) return h
 
     if(role === 'server') {
-      checkIP(ip)
-      checkPort(Number.parseInt(port))
-      punch.createOutboundHole(ep, ip, port)
+      return punch.createOutboundHole(ep)
     } else if(role === 'client') {
-      punch.createInboundHole(ep)
+      return punch.createInboundHole(ep)
     }
   }
 
-  function updateHoleInfo(ep, ip, port) {
+  function updateHoleInfo(ep, ip, port, cert) {
     checkIP(ip)
     checkPort(Number.parseInt(port))
-    punch.updateHoleInfo(ep, ip, port)
+    punch.updateHoleInfo(ep, ip, port, cert)
   }
 
   function syncPunch(ep) {

--- a/agent/apps/ztm/tunnel/api.js
+++ b/agent/apps/ztm/tunnel/api.js
@@ -189,19 +189,13 @@ export default function ({ app, mesh, punch }) {
   function updateHoleInfo(ep, ip, port) {
     checkIP(ip)
     checkPort(Number.parseInt(port))
-    console.info(`Updating nat info: peer ${ep}, ip ${ip}, port ${port}`)
     punch.updateHoleInfo(ep, ip, port)
   }
 
-  function punchHole(ep) {
-    console.log(`Hole punching......`)
+  function syncPunch(ep) {
     var hole = punch.findHole(ep)
-    // if(!hole) return null
+    if(!hole) throw `Invalid Hole State for ${ep}`
     hole.punch()
-  }
-
-  function makeRespTunnel(ep) {
-
   }
 
   function deleteHole(ep) {
@@ -395,6 +389,17 @@ export default function ({ app, mesh, punch }) {
     )
   )
 
+  var makeRespTunnel = pipeline($=>$
+    .onStart(ctx => {
+      console.info("Making resp tunnel: ", ctx)
+      var ep = ctx.peer.id
+      var hole = punch.findHole(ep)
+      if(!hole) throw `Invalid Hole State for ${ep}`
+      return hole
+    })
+    .pipe(hole => hole.makeRespTunnel())
+  )
+
   // var makeRespTunnel = pipeline($=>$
   //   .pipe(punch.makeRespTunnel())
   // )
@@ -414,7 +419,7 @@ export default function ({ app, mesh, punch }) {
     createHole,
     updateHoleInfo,
     makeRespTunnel,
-    punchHole,
+    syncPunch,
     deleteHole,
     servePeerInbound,
   }

--- a/agent/apps/ztm/tunnel/main.js
+++ b/agent/apps/ztm/tunnel/main.js
@@ -161,7 +161,7 @@ export default function ({ app, mesh, utils }) {
         var ip = $ctx.peer.ip
         var port = $ctx.peer.port
 
-        console.log(`Punch Event: ${action} from ${ep} ${ip} ${port}`)
+        app.log(`Punch Event: ${action} from ${ep} ${ip} ${port}`)
         switch(action) {
           case 'leave':
             api.deleteHole(ep, true)
@@ -178,8 +178,7 @@ export default function ({ app, mesh, utils }) {
         var ip = $ctx.peer.ip
         var port = $ctx.peer.port
 
-        console.log(`Punch Event: ${action} from ${ep} ${ip} ${port}`)
-        console.log("Punch req: ", obj)
+        app.log(`Punch Event: ${action} from ${ep} ${ip} ${port}`)
         switch(action) {
           case 'request':
             api.createHole(ep, 'server')

--- a/agent/apps/ztm/tunnel/main.js
+++ b/agent/apps/ztm/tunnel/main.js
@@ -84,9 +84,14 @@ export default function ({ app, mesh, utils }) {
       }),
     },
 
-    '/api/punch/{otbEp}/{inbEp}': {
-      'GET': responder(({otbEp, inbEp}) => {
+    '/api/punch/{destEp}': {
+      'GET': responder(({destEp}) => {
+        return api.createHole(destEp)
+      }),
 
+      'DELETE': responder(({destEp}) => {
+        api.deleteHole(destEp)
+        return response(204)
       })
     },
 
@@ -144,6 +149,18 @@ export default function ({ app, mesh, utils }) {
       }),
 
       'CONNECT': api.servePeerInbound,
+    },
+
+    '/api/punch/{role}': {
+      'GET': responder(({role}) => {
+        var ep = $ctx.id
+        var ip = $ctx.ip
+        var port = $ctx.port
+
+        return api.createHole(ep, ip, port, role)
+      }),
+
+      'CONNECT': api.makeRespTunnel
     },
   })
 

--- a/agent/apps/ztm/tunnel/main.js
+++ b/agent/apps/ztm/tunnel/main.js
@@ -1,8 +1,10 @@
 import initAPI from './api.js'
 import initCLI from './cli.js'
+import initHole from './punch.js'
 
 export default function ({ app, mesh, utils }) {
-  var api = initAPI({ app, mesh })
+  var punch = initHole({ app })
+  var api = initAPI({ app, mesh, punch })
   var cli = initCLI({ app, mesh, utils, api })
 
   var $ctx
@@ -80,6 +82,12 @@ export default function ({ app, mesh, utils }) {
       'DELETE': responder(({ ep, proto, name }) => {
         return api.deleteOutbound(ep, proto, name).then(response(204))
       }),
+    },
+
+    '/api/punch/{otbEp}/{inbEp}': {
+      'GET': responder(({otbEp, inbEp}) => {
+
+      })
     },
 
     '*': {

--- a/agent/apps/ztm/tunnel/main.js
+++ b/agent/apps/ztm/tunnel/main.js
@@ -163,15 +163,29 @@ export default function ({ app, mesh, utils }) {
 
         console.log(`Punch Event: ${action} from ${ep} ${ip} ${port}`)
         switch(action) {
+          case 'leave':
+            api.deleteHole(ep, true)
+            break
+          default:
+            return Promise.resolve(response(500, "Unknown punch action"))
+        }
+        return Promise.resolve(response(200))
+      }),
+
+      'POST': responder(({action}, req) => {
+        var obj = JSON.decode(req.body)
+        var ep = $ctx.peer.id
+        var ip = $ctx.peer.ip
+        var port = $ctx.peer.port
+
+        console.log(`Punch Event: ${action} from ${ep} ${ip} ${port}, time ${obj.timestamp}`)
+        switch(action) {
           case 'request':
             api.createHole(ep, ip, port, 'server')
             break
           case 'accept':
             api.updateHoleInfo(ep, ip, port)
             api.syncPunch(ep)
-            break
-          case 'leave':
-            api.deleteHole(ep, true)
             break
           default:
             return Promise.resolve(response(500, "Unknown punch action"))

--- a/agent/apps/ztm/tunnel/main.js
+++ b/agent/apps/ztm/tunnel/main.js
@@ -187,7 +187,6 @@ export default function ({ app, mesh, utils }) {
     // Tricky callback to set ctx,
     // expecting everything in hole works
     // just like it's coming from hub.
-    console.info("Setting ctx manually: ", ctx)
     $ctx = ctx
     return servePeer
   })

--- a/agent/apps/ztm/tunnel/main.js
+++ b/agent/apps/ztm/tunnel/main.js
@@ -178,13 +178,18 @@ export default function ({ app, mesh, utils }) {
         var ip = $ctx.peer.ip
         var port = $ctx.peer.port
 
-        console.log(`Punch Event: ${action} from ${ep} ${ip} ${port}, time ${obj.timestamp}`)
+        console.log(`Punch Event: ${action} from ${ep} ${ip} ${port}`)
+        console.log("Punch req: ", obj)
         switch(action) {
           case 'request':
-            api.createHole(ep, ip, port, 'server')
+            api.createHole(ep, 'server')
+            api.updateHoleInfo(ep, ip, port, obj.cert)
+            api.syncPunch(ep)
+            // var certs = hole.signPeerCert(new crypto.PublicKey(obj.pkey))
+            // return Promise.resolve(response(200, cert))
             break
           case 'accept':
-            api.updateHoleInfo(ep, ip, port)
+            api.updateHoleInfo(ep, ip, port, obj.cert)
             api.syncPunch(ep)
             break
           default:

--- a/agent/apps/ztm/tunnel/main.js
+++ b/agent/apps/ztm/tunnel/main.js
@@ -1,6 +1,6 @@
+import initHole from './punch.js'
 import initAPI from './api.js'
 import initCLI from './cli.js'
-import initHole from './punch.js'
 
 export default function ({ app, mesh, utils }) {
   var punch = initHole({ app, mesh })
@@ -170,13 +170,16 @@ export default function ({ app, mesh, utils }) {
             api.updateHoleInfo(ep, ip, port)
             api.syncPunch(ep)
             break
+          case 'leave':
+            api.deleteHole(ep, true)
+            break
           default:
             return Promise.resolve(response(500, "Unknown punch action"))
         }
         return Promise.resolve(response(200))
       }),
 
-      'CONNECT': pipeline($=>$.onStart(() => $ctx).pipe(() => api.makeRespTunnel))
+      'CONNECT': pipeline($=>$.pipe(api.makeRespTunnel, () => $ctx))
     },
   })
 

--- a/agent/apps/ztm/tunnel/punch.js
+++ b/agent/apps/ztm/tunnel/punch.js
@@ -73,7 +73,7 @@ export default function ({ app, mesh }) {
               .connect(() => `${destIP}:${destPort}`, {
                 bind: bound,
                 onState: function (conn) {
-                  console.info("Conn Info: ", conn, tlsState)
+                  console.info("Conn Info: ", conn)
 
                   if (conn.state === 'open') {
                     conn.socket.setRawOption(1, 15, new Data([1, 0, 0, 0]))
@@ -240,6 +240,14 @@ export default function ({ app, mesh }) {
         subject: { CN: role },
         publicKey: pKey,
         privateKey: key,
+        days: 365,
+      })
+
+      cert = new crypto.Certificate({
+        subject: { CN: role },
+        publicKey: pKey,
+        privateKey: key,
+        issuer: cert,
         days: 365,
       })
 

--- a/agent/apps/ztm/tunnel/punch.js
+++ b/agent/apps/ztm/tunnel/punch.js
@@ -1,0 +1,382 @@
+export default function({ app }) {
+  var holes = {}
+
+
+  // Only available for symmetric NAT
+  function Hole(ep) {
+    // FIXME: throw on init fail?
+    // TODO: Add detailed comment.
+
+    // create hole when find ep.
+    // hub save ep pair that fail or success
+    var bound = '0.0.0.0:' + randomPort()   // local port that the hole using
+    var destIP                              // dest ip out of NAT
+    var destPort                            // dest port out of NAT
+    var role = null                         // server or client
+    // var managedSvc = {}
+
+    // closed forwarding connecting(ready punching) connected fail
+    var state = 'closed'  // inner state
+    var ready = false     // exposed state
+    var $hubConnection = null
+    var $connection = null
+    var $hub = null
+    var $pHub = new pipeline.Hub
+    var $session
+    var $response
+
+    console.info("Bound: ", bound)
+
+    // Check if ep is self.
+    if(ep === app.endpoint.id) {
+      throw 'Must not create a hole to self'
+    }
+
+    // A temp tunnel to help hub gather NAT info.
+    var hubSession = pipeline($ => $
+      .onStart(() => {
+        return selectHub(ep).then(res => {
+          if(res) {
+            $hub = res
+          } else {
+            state = 'fail'
+          }
+          return new Data
+        })
+      })
+      .muxHTTP(() => ep + "hub", { version: 2 }).to($ => $
+        .connectTLS({
+          ...tlsOptions,
+          onState: (session) => {
+            var err = session.error
+            if (err) state = 'fail'
+          }
+        }).to($ => $
+          .connect(() => $hub, {
+            onState: function (conn) {
+              console.info('Tmp connection state ', conn, state)
+              $hubConnection = conn
+              if (conn.state === 'open') {
+                // SOL_SOCKET & SO_REUSEPORT
+                conn.socket.setRawOption(1, 15, new Data([1]))
+              } else if (conn.state === 'connected' && state === 'closed') {
+                console.info("Tmp Hub Connection created")
+                state = 'forwarding'
+                reverseServer.spawn()
+              } else if (conn.state === 'closed' && state === 'forwarding') {
+                // this means closed unexpectedly
+                state = 'fail'
+                leave()
+              }
+            },
+            bind: bound,
+          })
+        )
+      )
+    )
+
+    var reverseServer = pipeline($ => $
+      .onStart(new Data)
+      .repeat(() => new Timeout(5).wait().then(() => {
+        if (state != 'forwarding') {
+          $hubConnection.close()
+          return false
+        }
+        return true
+      })).to($ => $
+        .loop($ => $
+          .connectHTTPTunnel(
+            new Message({
+              method: 'CONNECT',
+              path: `/api/punch/${config.agent.id}/${ep}`,
+            })
+          )
+          .to(hubSession)
+          .pipe(servePunch)
+        )
+      )
+    )
+
+    var servePunch = pipeline($ => $
+      .demuxHTTP().to($ => $.pipe(() => {
+        var routes = Object.entries({
+          '/api/punch/{srcEp}/{destEp}/sync': {
+            // Hub sent synchronize message. Once receive, start punch.
+            // Agent <- Hub -> Remote Agent.
+            'POST': function (params, req) {
+              // TODO use params to check
+              var body = JSON.decode(req.body)
+              destIP = body.destIP
+              destPort = body.port
+              state = 'ready'
+
+              punch(destIP, destPort)
+            }
+          },
+        }).map(function ([path, methods]) {
+          var match = new http.Match(path)
+          var handler = function (params, req) {
+            var f = methods[req.head.method]
+            if (f) return f(params, req)
+            return response(405)
+          }
+          return { match, handler }
+        })
+
+        return pipeline($ => $
+          .replaceMessage(
+            function (req) {
+              var params
+              var path = req.head.path
+              var route = routes.find(r => Boolean(params = r.match(path)))
+              if (route) {
+                try {
+                  var res = route.handler(params, req)
+                  return res instanceof Promise ? res.catch(responseError) : res
+                } catch (e) {
+                  return responseError(e)
+                }
+              }
+              meshError('Invalid api call from hub')
+              return response(404)
+            }
+          )
+        )
+      }
+      ))
+    )
+
+    function directSession() {
+      // TODO !!! state error would happen when network is slow
+      // must handle this
+
+      if (!role) meshError('Hole not init correctly')
+      if ($session) return $session
+
+      // TODO: support TLS connection
+      if (role === 'client') {
+        // make session to server side directly
+        $session = pipeline($ => $
+          .muxHTTP(() => ep + "direct", { version: 2 }).to($ => $
+            .connect(() => `${destIP}:${destPort}`, {
+              onState: function (conn) {
+                if (conn.state === 'open') {
+                  conn.socket.setRawOption(1, 15, new Data([1]))
+                } else if (conn.state === 'connected') {
+                  logInfo(`Connected to remote ${destIP}:${destPort}`)
+                  $connection = conn
+                  state = 'connected'
+                } else if (conn.state === 'closed') {
+                  logInfo(`Disconnected from remote ${destIP}:${destPort}`)
+                  $connection = null
+                  state = 'closed'
+                }
+              },
+              bind: bound
+            })
+            .handleStreamEnd(evt => {
+              if (evt.error) {
+                state = 'fail'
+                leave()
+              }
+            })
+          )
+        )
+
+        // reverse server for receiving requests
+        pipeline($ => $
+          .onStart(new Data)
+          .repeat(() => new Timeout(5).wait().then(() => {
+            return state != 'fail' || state != 'closed'
+          })).to($ => $
+            .loop($ => $
+              .connectHTTPTunnel(
+                new Message({
+                  method: 'CONNECT',
+                  path: `/api/punch/${config.agent.id}/${ep}`,
+                })
+              )
+              .to($session)
+              .pipe(serveHub)
+            )
+          )
+        ).spawn()
+
+      } else if (role === 'server') {
+        pipy.listen(bound, 'tcp', serveHub)
+
+        $session = pipeline($ => $
+          .muxHTTP(() => ep + "direct", { version: 2 }).to($ => $
+            .swap(() => $pHub)
+          )
+        )
+      }
+
+      return $session
+    }
+
+    // Send a request.
+    var request = pipeline($ => $
+      .onStart(msg => {
+        console.info(`Reqesting Remote: ${JSON.encode(msg.head)}`)
+        return msg
+      })
+      .pipe(() => {
+        if (state === 'connected') {
+          return directSession()
+        } else if(state != 'fail') {
+          return hubSession
+        }
+
+        console.log(`State incorrect: ${state}, reject`)
+        return pipeline($=>$.dummy())
+      })
+      .handleMessage(msg => $response = msg)
+      .replaceMessage(new StreamEnd)
+      .onEnd(() => $response)
+    )
+
+    // use THE port sending request to hub.
+    function requestPunch() {
+      // FIXME: add state check
+      // state = 'connecting'
+      role = 'client'
+
+      request.spawn(new Message({
+        method: 'GET',
+        path: `/api/punch/${config.agent.id}/${ep}/request`,
+      }))
+    }
+
+    // TODO add cert info into response
+    function acceptPunch() {
+      // state = 'connecting'
+      role = 'server'
+
+      request.spawn(new Message({
+        method: 'POST',
+        path: `/api/punch/${config.agent.id}/${ep}/reqeust`,
+      }))
+    }
+
+    function punch(destIP, destPort) {
+      // receive TLS options
+      // connectTLS
+      // connectLocal or connectRemote
+
+      // TODO add retry logic here
+      state = 'punching'
+      makeFakeCall(destIP, destPort)
+      $session = directSession()
+      heartbeat() // activate the session pipeline
+    }
+
+    function makeRespTunnel() {
+      // TODO add state check
+      state = 'connected'
+
+      return pipeline($ => $
+        .acceptHTTPTunnel(() => response200()).to($ => $
+          .onStart(new Data)
+          .swap(() => $pHub)
+          .onEnd(() => console.info(`Direct Connection from ${ep} lost`))
+        )
+      )
+    }
+
+    // send a SYN to dest, expect no return.
+    // this will cheat the firewall to allow inbound connection from dest.
+    function makeFakeCall(destIP, destPort) {
+      pipy().task().onStart(new Data).connect(`${destIP}:${destPort}`, {
+        bind: bound,
+        onState: function (conn) {
+          // REUSEPORT
+          if (conn.state === 'open') conn.socket.setRawOption(1, 15, new Data([1]))
+
+          // abort this connection.
+          if (conn.state === 'connecting') conn.close()
+        }
+      })
+    }
+
+
+    function heartbeat() {
+      request.spawn(
+        new Message(
+          { method: 'POST', path: '/api/status' },
+          JSON.encode({ name: config.agent.name })
+        )
+      )
+    }
+
+    function leave() {
+      $hubConnection?.close()
+      $connection?.close()
+      $hubConnection = null
+      $connection = null
+      if (state != 'fail') state = 'closed'
+
+      // try to find the hub holding this hole
+      if($hub) {
+        var parent = hubs.find(h => $hub === h.address)
+        parent.updateHoles()
+      }
+    }
+
+    return {
+      role,
+      ready,
+      destIP,
+      destPort,
+      requestPunch,
+      acceptPunch,
+      punch,
+      makeRespTunnel,
+      directSession,
+      heartbeat,
+      leave,
+    }
+  } // End of Hole
+
+  function createInboundHole(ep) {
+    try {
+      var hole = Hole(ep)
+    } catch {
+      app.log(`Failed to create Inbound Hole, peer ${ep}`)
+    }
+
+    hole.requestPunch()
+  }
+
+  function createOutboundHole(proto, name) {
+    try {
+      var hole = Hole(ep)
+    } catch {
+      app.log(`Failed to create Inbound Hole, peer ${ep}`)
+    }
+
+    hole.acceptPunch()
+  }
+
+  function deleteHole(ep) {
+    
+  }
+
+  function findHole(ep) {
+
+  }
+
+  function isHoleReady(hole) {
+
+  }
+
+
+  return {
+    holes,
+    createInboundHole,
+    createOutboundHole,
+    deleteHole,
+    findHole,
+    isHoleReady,
+  }
+}

--- a/agent/apps/ztm/tunnel/punch.js
+++ b/agent/apps/ztm/tunnel/punch.js
@@ -237,17 +237,9 @@ export default function ({ app, mesh }) {
       var key = new crypto.PrivateKey({ type: 'rsa', bits: 2048 })
       var pKey = new crypto.PublicKey(key)
       var cert = new crypto.Certificate({
-        subject: { CN: 'Fake CA' },
-        publicKey: pKey,
-        privateKey: key,
-        days: 365,
-      })
-
-      cert = new crypto.Certificate({
         subject: { CN: role },
         publicKey: pKey,
         privateKey: key,
-        issuer: cert,
         days: 365,
       })
 


### PR DESCRIPTION
Tip: Starting agents with --reuse-port or the hole punching won't work.

When sending data from inbound side to outbound side, it will try to punch a hole and connect to peer directly.
If the hole punch process works, both the inbound and outbound network traffic will be redirected to the direct connection.
If not work, it will behave like there's not such a feature.